### PR TITLE
Fixed the crash caused by moving the mouse when in the Chinese input …

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4979,6 +4979,10 @@ String TextEdit::get_word(int p_line, int p_column) const {
 }
 
 Point2i TextEdit::get_line_column_at_pos(const Point2i &p_pos, bool p_clamp_line, bool p_clamp_column) const {
+	// If IME is active, return current cursor position directly to prevent crash.
+	if (has_ime_text()) {
+		return Point2i(get_caret_column(), get_caret_line());
+	}  
 	float rows = p_pos.y - theme_cache.style_normal->get_margin(SIDE_TOP);
 	if (!editable) {
 		rows -= theme_cache.style_readonly->get_offset().y / 2;


### PR DESCRIPTION
…method pre-input state

to solve this issue 
https://github.com/godotengine/godot/issues/110138

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
